### PR TITLE
fix: stale model IDs and config keys that hooks silently ignore

### DIFF
--- a/.ai-hooks.example.yml
+++ b/.ai-hooks.example.yml
@@ -15,10 +15,10 @@
 provider: claude
 
 # Model to use (provider-specific).
-# Claude:  claude-sonnet-4-5-20250514, claude-haiku-35
+# Claude:  claude-sonnet-4-6, claude-haiku-4-5
 # OpenAI:  gpt-4o, gpt-4o-mini
 # Ollama:  llama3.1, codellama, mistral
-model: claude-sonnet-4-5-20250514
+model: claude-sonnet-4-6
 
 # Maximum tokens the AI can return in a single response.
 # Higher values allow more detailed reviews but cost more.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -88,7 +88,7 @@ body:
       render: yaml
       placeholder: |
         provider: claude
-        model: claude-sonnet-4-5-20250514
+        model: claude-sonnet-4-6
         hooks:
           pre-commit:
             enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,7 +43,7 @@
 
 ## Checklist
 
-- [ ] My code follows the project's [style guide](CONTRIBUTING.md#style-guide)
+- [ ] My code follows the project's [style guide](../CONTRIBUTING.md#style-guide)
 - [ ] I have updated documentation for any changed behavior
 - [ ] I have added/updated the example config (`.ai-hooks.example.yml`) if I added new options
 - [ ] I have added tests for my changes

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ hooks:
   pre-commit:
     enabled: true
     severity: warn          # error | warn | info
-    max-files: 20
+    max_files: 20
     ignore:
       - "*.lock"
       - "*.min.js"
@@ -49,18 +49,18 @@ hooks:
   prepare-commit-msg:
     enabled: true
     style: conventional     # conventional | simple | detailed
-    prefix: true            # auto-detect ticket from branch name
+    ticket_prefix: true     # auto-detect ticket from branch name
 
   commit-msg:
     enabled: true
     convention: conventional
-    max-length: 72
+    max_length: 72
 
   pre-push:
     enabled: true
-    scan-secrets: true
-    scan-dependencies: true
-    max-file-size: 5MB
+    scan_secrets: true
+    scan_dependencies: true
+    max_file_size: 5MB
 ```
 
 ### 3. Set your API key


### PR DESCRIPTION
- example config shipped claude-sonnet-4-5-20250514 (malformed snapshot
  ID -- 20250514 is the Sonnet 4 date, retiring 2026-06-15) and
  suggested retired claude-haiku-35; now claude-sonnet-4-6 +
  claude-haiku-4-5, matching what all 4 hook scripts default to
- README config example used kebab-case keys (max-files, prefix,
  scan-secrets...) but yaml_get parses snake_case only, so copied
  configs were silently ignored; now matches .ai-hooks.example.yml
- bug-report template placeholder updated; PR template style-guide
  link fixed (.github/ -> repo root)
