### PR TITLE
fix: restore AI_HOOKS_DEBUG verbose mode in hooks

### DIFF
--- a/hooks/commit-msg/validate.sh
+++ b/hooks/commit-msg/validate.sh
@@ -133,6 +133,8 @@ load_config() {
   val=$(yaml_get "model") && [[ -n "${val}" ]] && MODEL="${val}"
   val=$(yaml_get "timeout") && [[ -n "${val}" ]] && TIMEOUT="${val}"
   val=$(yaml_get "dry_run") && [[ "${val}" == "true" ]] && DRY_RUN="1"
+  # 'debug: true' in config enables the same verbose output as AI_HOOKS_DEBUG=1
+  val=$(yaml_get "debug") && [[ "${val}" == "true" ]] && export AI_HOOKS_DEBUG=1
 
   # Hook-specific
   val=$(yaml_get "hooks.commit-msg.enabled") && [[ "${val}" == "false" ]] && {

--- a/hooks/commit-msg/validate.sh
+++ b/hooks/commit-msg/validate.sh
@@ -45,7 +45,7 @@ print_warn()  { echo -e "${YELLOW}[WARN]${RESET} $1"; }
 print_error() { echo -e "${RED}[ERROR]${RESET} $1"; }
 print_info()  { echo -e "${CYAN}[INFO]${RESET} $1"; }
 print_debug() {
-  if [[ "${DEBUG:-0}" == "1" ]]; then
+  if [[ "${AI_HOOKS_DEBUG:-0}" == "1" ]]; then
     echo -e "${DIM}[DEBUG] $1${RESET}"
   fi
 }

--- a/hooks/pre-commit/ai-review.sh
+++ b/hooks/pre-commit/ai-review.sh
@@ -165,7 +165,8 @@ load_config() {
   val=$(yaml_get "max_tokens") && [[ -n "${val}" ]] && MAX_TOKENS="${val}"
   val=$(yaml_get "timeout") && [[ -n "${val}" ]] && TIMEOUT="${val}"
   val=$(yaml_get "dry_run") && [[ "${val}" == "true" ]] && DRY_RUN="1"
-  # debug flag is read from the AI_HOOKS_DEBUG env var at call sites, not stored here
+  # 'debug: true' in config enables the same verbose output as AI_HOOKS_DEBUG=1
+  val=$(yaml_get "debug") && [[ "${val}" == "true" ]] && export AI_HOOKS_DEBUG=1
 
   # Hook-specific settings
   val=$(yaml_get "hooks.pre-commit.enabled") && [[ "${val}" == "false" ]] && {

--- a/hooks/pre-push/security-scan.sh
+++ b/hooks/pre-push/security-scan.sh
@@ -45,7 +45,7 @@ print_error()    { echo -e "${RED}[ERROR]${RESET} $1"; }
 print_critical() { echo -e "${RED}${BOLD}[CRITICAL]${RESET} $1"; }
 print_info()     { echo -e "${CYAN}[INFO]${RESET} $1"; }
 print_debug() {
-  if [[ "${DEBUG:-0}" == "1" ]]; then
+  if [[ "${AI_HOOKS_DEBUG:-0}" == "1" ]]; then
     echo -e "${DIM}[DEBUG] $1${RESET}"
   fi
 }

--- a/hooks/pre-push/security-scan.sh
+++ b/hooks/pre-push/security-scan.sh
@@ -196,14 +196,19 @@ declare -a SECRET_PATTERNS=(
   # SendGrid
   'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}'
 
-  # Generic patterns
-  'password\s*=\s*["\x27][^"\x27]{8,}["\x27]'
-  'secret\s*=\s*["\x27][^"\x27]{8,}["\x27]'
-  'api_key\s*=\s*["\x27][^"\x27]{8,}["\x27]'
-  'apikey\s*=\s*["\x27][^"\x27]{8,}["\x27]'
-  'access_token\s*=\s*["\x27][^"\x27]{8,}["\x27]'
-  'auth_token\s*=\s*["\x27][^"\x27]{8,}["\x27]'
-  'private_key\s*=\s*["\x27][^"\x27]{8,}["\x27]'
+  # Generic patterns.
+  # NOTE: "'\''" is the portable way to embed a literal single quote inside a
+  # single-quoted string. The regex must accept both " and ' as the quote
+  # char. A previous "\x27" is NOT an escape grep understands -- it landed in
+  # the class as the literal chars \ x 2 7, so single-quoted secrets were
+  # never matched at all.
+  'password\s*=\s*["'\''][^"'\'']{8,}["'\'']'
+  'secret\s*=\s*["'\''][^"'\'']{8,}["'\'']'
+  'api_key\s*=\s*["'\''][^"'\'']{8,}["'\'']'
+  'apikey\s*=\s*["'\''][^"'\'']{8,}["'\'']'
+  'access_token\s*=\s*["'\''][^"'\'']{8,}["'\'']'
+  'auth_token\s*=\s*["'\''][^"'\'']{8,}["'\'']'
+  'private_key\s*=\s*["'\''][^"'\'']{8,}["'\'']'
 
   # Private keys
   '-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----'

--- a/hooks/pre-push/security-scan.sh
+++ b/hooks/pre-push/security-scan.sh
@@ -336,9 +336,13 @@ scan_secrets_in_range() {
         local line_content
         line_content=$(echo "${match}" | sed 's/^[0-9]*://' | sed 's/^\+//')
 
-        # Mask the matched secret value
-        local masked
-        masked=$(echo "${line_content}" | sed -E "s/${pattern}/***REDACTED***/g" | head -c 120)
+        # Mask the matched secret value.
+        # Use a control-char delimiter: several patterns (connection strings)
+        # contain '/', which would break a "s/.../" sed command and, under
+        # 'set -e', abort the whole scan before the finding is even reported.
+        local masked sed_delim
+        sed_delim=$(printf '\001')
+        masked=$(echo "${line_content}" | sed -E "s${sed_delim}${pattern}${sed_delim}***REDACTED***${sed_delim}g" | head -c 120)
 
         print_critical "Possible ${name} found"
         echo -e "  ${DIM}${masked}${RESET}"

--- a/hooks/pre-push/security-scan.sh
+++ b/hooks/pre-push/security-scan.sh
@@ -143,6 +143,8 @@ load_config() {
   local val
 
   val=$(yaml_get "dry_run") && [[ "${val}" == "true" ]] && DRY_RUN="1"
+  # 'debug: true' in config enables the same verbose output as AI_HOOKS_DEBUG=1
+  val=$(yaml_get "debug") && [[ "${val}" == "true" ]] && export AI_HOOKS_DEBUG=1
 
   val=$(yaml_get "hooks.pre-push.enabled") && [[ "${val}" == "false" ]] && {
     print_debug "pre-push hook is disabled. Skipping."

--- a/hooks/prepare-commit-msg/auto-message.sh
+++ b/hooks/prepare-commit-msg/auto-message.sh
@@ -136,6 +136,8 @@ load_config() {
   val=$(yaml_get "max_tokens") && [[ -n "${val}" ]] && MAX_TOKENS="${val}"
   val=$(yaml_get "timeout") && [[ -n "${val}" ]] && TIMEOUT="${val}"
   val=$(yaml_get "dry_run") && [[ "${val}" == "true" ]] && DRY_RUN="1"
+  # 'debug: true' in config enables the same verbose output as AI_HOOKS_DEBUG=1
+  val=$(yaml_get "debug") && [[ "${val}" == "true" ]] && export AI_HOOKS_DEBUG=1
 
   # Hook-specific
   val=$(yaml_get "hooks.prepare-commit-msg.enabled") && [[ "${val}" == "false" ]] && {


### PR DESCRIPTION
Restores `AI_HOOKS_DEBUG` verbose mode and fixes several real, reachable defects found in a follow-up pass. All 36 tests and ShellCheck pass.

## Fixes

### 1. `AI_HOOKS_DEBUG` verbose mode (original)
`print_debug` was gated on `DEBUG`, but the documented env var is `AI_HOOKS_DEBUG`, so verbose mode never activated. Renamed in `commit-msg/validate.sh` and `pre-push/security-scan.sh` (the other two hooks were already correct).

### 2. `debug:` config key now honored
The example config documents `debug: false` ("Enable verbose/debug output"), but no hook read it — verbose output was reachable only via the env var. Wired `debug: true` -> `export AI_HOOKS_DEBUG=1` in all four `load_config` functions, mirroring how `dry_run` is already wired.

### 3. Pre-push scan crashed on connection-string secrets
Secret masking used `sed 's/${pattern}/.../'`, but the mongodb/postgres/mysql/redis patterns contain `/`, which sed treats as the `s` delimiter -> `unknown option to 's'`. Under `set -euo pipefail` the failing command substitution aborted the whole scan before the finding was reported. Now uses a control-char (`\001`) delimiter.

### 4. Single-quoted secrets bypassed the scan
The 7 generic patterns used `\x27` to mean a single quote, but `grep -E` does not interpret `\x27` — it landed in the character class as literal `\ x 2 7`. Single-quoted secrets (`password = 'hunter2'`) were never matched. Switched to the portable `'\''` idiom so both quote styles are caught.