### PR TITLE
chore: default the claude provider to sonnet 5

### DIFF
--- a/.ai-hooks.example.yml
+++ b/.ai-hooks.example.yml
@@ -15,10 +15,10 @@
 provider: claude
 
 # Model to use (provider-specific).
-# Claude:  claude-sonnet-4-6, claude-haiku-4-5
+# Claude:  claude-sonnet-5, claude-opus-5, claude-haiku-4-5
 # OpenAI:  gpt-4o, gpt-4o-mini
 # Ollama:  llama3.1, codellama, mistral
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 
 # Maximum tokens the AI can return in a single response.
 # Higher values allow more detailed reviews but cost more.

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -88,7 +88,7 @@ body:
       render: yaml
       placeholder: |
         provider: claude
-        model: claude-sonnet-4-6
+        model: claude-sonnet-5
         hooks:
           pre-commit:
             enabled: true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Create `.ai-hooks.yml` in your project root:
 
 ```yaml
 provider: claude            # claude | openai | ollama
-model: claude-sonnet-4-6    # model to use
+model: claude-sonnet-5      # model to use
 
 hooks:
   pre-commit:

--- a/hooks/commit-msg/validate.sh
+++ b/hooks/commit-msg/validate.sh
@@ -154,7 +154,7 @@ load_config() {
 
   if [[ -z "${MODEL}" ]]; then
     case "${PROVIDER}" in
-      claude)  MODEL="claude-sonnet-4-6" ;;
+      claude)  MODEL="claude-sonnet-5" ;;
       openai)  MODEL="gpt-4o" ;;
       ollama)  MODEL="llama3.1" ;;
     esac

--- a/hooks/pre-commit/ai-review.sh
+++ b/hooks/pre-commit/ai-review.sh
@@ -190,7 +190,7 @@ load_config() {
   # Set default models per provider
   if [[ -z "${MODEL}" ]]; then
     case "${PROVIDER}" in
-      claude)  MODEL="claude-sonnet-4-6" ;;
+      claude)  MODEL="claude-sonnet-5" ;;
       openai)  MODEL="gpt-4o" ;;
       ollama)  MODEL="llama3.1" ;;
     esac

--- a/hooks/prepare-commit-msg/auto-message.sh
+++ b/hooks/prepare-commit-msg/auto-message.sh
@@ -151,7 +151,7 @@ load_config() {
 
   if [[ -z "${MODEL}" ]]; then
     case "${PROVIDER}" in
-      claude)  MODEL="claude-sonnet-4-6" ;;
+      claude)  MODEL="claude-sonnet-5" ;;
       openai)  MODEL="gpt-4o" ;;
       ollama)  MODEL="llama3.1" ;;
     esac


### PR DESCRIPTION
The Claude default was pinned to `claude-sonnet-4-6`, a legacy snapshot that retires 2027-02-17. Anyone installing these hooks today and not setting `model:` explicitly gets an outdated model. Sonnet 5 is the current Sonnet-tier flagship, and it is also cheaper right now on its $2/$10 intro rate through 2026-08-31.

Six references, enumerated with a repo-wide grep so nothing was left behind:

- `hooks/pre-commit/ai-review.sh`, `hooks/commit-msg/validate.sh`, `hooks/prepare-commit-msg/auto-message.sh` -- the `case "${PROVIDER}"` fallback in each. The third one is easy to miss; a truncated first grep did miss it, and the re-run caught it.
- `.ai-hooks.example.yml` -- the `model:` value plus the commented model list, which now names `claude-opus-5` as the step-up option
- `README.md` -- the quickstart config block
- `.github/ISSUE_TEMPLATE/bug-report.yml` -- the config placeholder

No behavior change beyond the default string. Config files that set `model:` explicitly are unaffected.

## Verification

`bash -n` passes on all three modified scripts, and both YAML files parse. I could not run shellcheck locally (not installed here), so the shellcheck job in `test.yml` is the real gate on this PR -- worth a look at the check result before merging.
